### PR TITLE
wrap test extra arguments with quotes

### DIFF
--- a/bin/ec2-ssh
+++ b/bin/ec2-ssh
@@ -49,7 +49,7 @@ if [ "$tag" ]; then
 fi
 host=$(eval "$host_cmd $inst" | head -n 1)
 
-if test "${@:2}"; then
+if test '"${@:2}"'; then
     # Pass extra parameters direct to ssh
     ssh_cmd=${@:2}
 else


### PR DESCRIPTION
Wrapping the test for extra arguments with quotes to inhibit
evaluation of command line arguments as arguments to test itself.

Test with

ec2-ssh user@host echo -n test