### PR TITLE
Rewrite ec2-ssh in Python

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,8 @@ Pending
 -------
 
 * Next version release notes here
+* ``ec2-ssh`` rewritten in Python. As part of this, the automatic 'pretty
+  prompt' has been removed.
 
 1.3.0 (2016-01-06)
 ------------------

--- a/bin/ec2-ssh
+++ b/bin/ec2-ssh
@@ -1,63 +1,63 @@
-#!/bin/bash
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+from __future__ import print_function
 
-set -e
+import argparse
+import os
+import subprocess
+import sys
 
-usage() {
-    cat<<EOF
-Usage: ec2-ssh [-t TAG] [username@]<tag-value> [extra-ssh-args]
-
-SSH into an ec2 host where <tag-value> matches a tag which defaults to 'Name'
-or environment variable EC2_HOST_TAG. In the case there is more than one such
-instance, one will be chosen at random. 'username' defaults to ubuntu.  A small
-bashrc file is added over ssh to give a nice prompt. Any extra arguments at the
-end are passed to ssh directly.
-
-  -h            display this help and exit
-  -t, TAG       Tag name to match, defaults to 'Name' or env var EC2_HOST_TAG
-EOF
-}
-
-# Print usage message and exit if no arguments are given
-test $# -eq 0 && { usage; exit; }
+parser = argparse.ArgumentParser(
+    description="""
+    SSH into an ec2 host where <tag-value> matches a tag which defaults to
+    'Name' or environment variable EC2_HOST_TAG. In the case there is more than
+    one such instance, one will be chosen at random. 'username' defaults to
+    ubuntu.  A small bashrc file is added over ssh to give a nice prompt. Any
+    extra arguments at the end are passed to ssh directly.
+    """
+)
+parser.add_argument('-t', '--tag', type=str,
+                    default=None, help="Tag to match, defaults to 'Name'")
+parser.add_argument('value', help="The value for the tag to match")
 
 
-# Process options
-tag=$EC2_HOST_TAG  # default
-while getopts ":h:t:" opt; do
-    case $opt in
-        h  ) usage; exit 1;;
-        t  ) tag=$OPTARG
-    esac
-done
-shift $((OPTIND - 1))
+def main():
+    args, unparsed = parser.parse_known_args()
 
-# support user@instance-name format
-IFS="@"; declare -a hostparts=($1)
+    if '@' in args.value:
+        username, value = args.value.split('@', 1)
+    else:
+        username = 'ubuntu'
+        value = args.value
 
-inst="${hostparts[1]}"
-user="${hostparts[0]}"
+    host_name = get_host_name(args.tag, value)
 
-if [ -z "$inst" ]; then
-  inst="$1"
-  user="ubuntu"
-fi
+    if not host_name:
+        print("ec2-ssh: no hosts matched", file=sys.stderr)
+        sys.exit(1)
 
-# get host from ec2-host command - if more than one, take first
-host_cmd="ec2-host"
-if [ "$tag" ]; then
-    host_cmd="$host_cmd -t $tag"
-fi
-host=$(eval "$host_cmd $inst" | head -n 1)
+    command = [
+        'ssh',
+        '-t', '-t',
+        username + '@' + host_name,
+    ]
+    if unparsed:
+        command.extend(unparsed)
 
-if test "${@:2}"; then
-    # Pass extra parameters direct to ssh
-    ssh_cmd=${@:2}
-else
-    # If no extra parameters, set a nice prompt
-    ssh_cmd="\"echo \\\". ~/.bashrc && PS1='\[\e]0;$inst: \w\\\a\]\[\\\033[01;32m\]$inst\[\\\033[00m\]:\[\\\033[01;34m\]\w\[\\\033[00m\]\\\$ '\\\" > ~/.ec2sshrc; /bin/bash --rcfile .ec2sshrc -i\""
-fi
-ssh_cmd="ssh -t $user@$host $ssh_cmd"
+    print("ec2-ssh connecting to {}".format(host_name), file=sys.stderr)
+    sys.stdout.flush()
+    os.execlp(*command)
 
-test -n "$host" && \
-    echo "Connecting to $host." >&2 && \
-    exec sh -c "$ssh_cmd"
+
+def get_host_name(tag, value):
+    command = ["ec2-host"]
+    if tag:
+        command.extend(["-t", tag])
+    command.append(value)
+
+    hosts = subprocess.check_output(command)
+    return hosts[:hosts.find('\n')]
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
It's a lot cleaner in Python. This removes the pretty prompt setting, but I don't think it's a killer feature - often it's preferable to see the prompt, plus it was fixing the shell to bash which might not be preferable.
