### PR TITLE
Python3 fix

### DIFF
--- a/bin/ec2-ssh
+++ b/bin/ec2-ssh
@@ -56,7 +56,7 @@ def get_host_name(tag, value):
     command.append(value)
 
     hosts = subprocess.check_output(command)
-    return hosts[:hosts.find('\n')]
+    return hosts[:hosts.find(b'\n')].decode('utf-8')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
the subprocess module output is bytes in Python3, and
we need to take that into account when splitting for '\n'
and then re-convert to string
