### PR TITLE
Only use instances in the 'running' state

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,8 @@ Pending
 -------
 
 * Next version release notes here
+* Both ``ec2-host`` and ``ec2-ssh`` now only show/use instances in the
+  ``running`` state.
 
 1.8.0 (2017-07-19)
 ------------------

--- a/ec2_ssh.py
+++ b/ec2_ssh.py
@@ -85,7 +85,12 @@ def host():
 def get_dns_names(tag, value):
     conn = boto3.client('ec2')
 
-    filters = []
+    filters = [
+        {
+            'Name': 'instance-state-name',
+            'Values': ['running'],
+        }
+    ]
     if value:
         filters.append({
             'Name': 'tag:' + tag,


### PR DESCRIPTION
Instances in other states are either impossible to SSH into (e.g. terminated) or unlikely desirable (pending, probably not ready).

Fixes #22.